### PR TITLE
Updated path where to find probe_key.pub on Raspbian/Debian 12

### DIFF
--- a/manuals/Raspbian-source.en.md
+++ b/manuals/Raspbian-source.en.md
@@ -10,4 +10,4 @@ The Debian Build system includes support for x86_64 (amd64), arm64 and armhf. No
 2. Installing the probe software generates a new SSH key pair to be used to
    connect the probe to the RIPE Atlas infrastructure. You need to register
    the public key part to in order to [register the probe](https://atlas.ripe.net/apply/swprobe/).
-   This can be found in `/var/atlas-probe/etc/probe_key.pub`.
+   This can be found in `/etc/ripe-atlas/probe_key.pub`.


### PR DESCRIPTION
New path for probe_key.pub on Raspbian/Debian 12 is `/etc/ripe-atlas/probe_key.pub`. I verified this when I installed my own software probe. 